### PR TITLE
Set authentication listener public

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -36,7 +36,7 @@
             </argument>
         </service>
 
-        <service id="vipx_bot_detect.security.authentication_listener" class="%vipx_bot_detect.security.authentication_listener.class%" public="false">
+        <service id="vipx_bot_detect.security.authentication_listener" class="%vipx_bot_detect.security.authentication_listener.class%">
             <argument type="service" id="security.context" />
             <argument type="service" id="vipx_bot_detect.detector" />
         </service>


### PR DESCRIPTION
I got this error when I try to use the authentication listener: 

```
Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'The service &quot;vipx_bot_detect.security.authentication_listener&quot; must be public as event listeners are lazy-loaded
```

It works fine if I remove public=false
