### PR TITLE
fixed Vipx\BotDetect class parameters

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,8 +7,8 @@
     <parameters>
         <parameter key="vipx_bot_detect.metadata.resolver.class">Symfony\Component\Config\Loader\LoaderResolver</parameter>
         <parameter key="vipx_bot_detect.metadata.loader.class">Symfony\Component\Config\Loader\DelegatingLoader</parameter>
-        <parameter key="vipx_bot_detect.metadata.loader.yml.class">Vipx\BotDetect\Bot\Metadata\Loader\YamlFileLoader</parameter>
-        <parameter key="vipx_bot_detect.metadata.dumper.class">Vipx\BotDetect\Bot\Metadata\Dumper\PhpMetadataDumper</parameter>
+        <parameter key="vipx_bot_detect.metadata.loader.yml.class">Vipx\BotDetect\Metadata\Loader\YamlFileLoader</parameter>
+        <parameter key="vipx_bot_detect.metadata.dumper.class">Vipx\BotDetect\Metadata\Dumper\PhpMetadataDumper</parameter>
         <parameter key="vipx_bot_detect.detector.class">Vipx\BotDetectBundle\BotDetector</parameter>
         <parameter key="vipx_bot_detect.security.authentication_listener.class">Vipx\BotDetect\Security\BotAuthenticationListener</parameter>
         <parameter key="vipx_bot_detect.metadata_file_locator.class">Vipx\BotDetectBundle\Config\MetadataFileLocator</parameter>


### PR DESCRIPTION
Commit 2044c6d937835237a00a601d4882b5a943b0986f introduced an error as the YamlFileLoader and the PhpMetadataDumper tried to be imported from a wrong path.
This PR fixes this issue.
