### PR TITLE
Allow symfony ^2.7 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/framework-bundle": "^3.0",
-        "symfony/security-bundle": "^3.0",
+        "symfony/framework-bundle": "^2.7 || ^3.0",
+        "symfony/security-bundle": "^2.7 || ^3.0",
         "vipx/bot-detect": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
As symfony 2.7 is still supported, and this bundle seems compatible (the token storage changes made [here](https://github.com/lennerd/VipxBotDetectBundle/pull/14/files) was introduced in 2.6), it would be nice to keep 2.7 and 2.8 compatibility (and it is usefull to be able to made every package compatible before upgrading a big project to SF 3)